### PR TITLE
Remove links to Claude work wife page

### DIFF
--- a/index-old.html
+++ b/index-old.html
@@ -928,7 +928,6 @@
             <br>
             <span class="quote">&gt;mods are asleep, post <a href="sinks.html" class="wikiEgg">sinks</a></span><br>
             <span class="quote">&gt;mfw when the <a href="https://en.wikipedia.org/wiki/Paperclip_maximizer" target="_blank" class="wikiEgg">paperclip maximizer</a> becomes sentient</span><br>
-            <span class="quote">&gt;tfw you need <a href="claude.html" class="wikiEgg">trusted counsel</a> before shipping</span><br>
             <span class="quote">&gt;check em <a href="https://en.wikipedia.org/wiki/Dubs" target="_blank" class="wikiEgg">dubs</a> decides next project</span>
           </blockquote>
         </div>

--- a/index.html
+++ b/index.html
@@ -842,7 +842,6 @@
         <a href="fireworks-view.html">🎆 Fireworks</a>
         <a href="world-desserts.html">🍰 World Desserts</a>
         <a href="sinks.html">🚰 Sinks</a>
-        <a href="claude.html">🤖 Claude</a>
         <a href="physics.html" style="color: #ff0000; font-weight: bold;">⚔️ /physics/</a>
       </div>
     </span>]
@@ -1454,7 +1453,6 @@
             <br>
             <span class="quote">&gt;mods are asleep, post <a href="sinks.html" class="wikiEgg">sinks</a></span><br>
             <span class="quote">&gt;mfw when the <a href="https://en.wikipedia.org/wiki/Paperclip_maximizer" target="_blank" class="wikiEgg">paperclip maximizer</a> becomes sentient</span><br>
-            <span class="quote">&gt;tfw you need <a href="claude.html" class="wikiEgg">trusted counsel</a> before shipping</span><br>
             <span class="quote">&gt;check em <a href="https://en.wikipedia.org/wiki/Dubs" target="_blank" class="wikiEgg">dubs</a> decides next project</span>
           </blockquote>
         </div>


### PR DESCRIPTION
Unlinked claude.html from navigation dropdown and greentext quotes in both index.html and index-old.html.

https://claude.ai/code/session_01LnAPJsaeQs2F3FPHZeBm7i